### PR TITLE
parse: use strings.HasSuffix instead of is()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/test/testfile
+/systemgo
+/systemctl/systemctl
+*~
+


### PR DESCRIPTION
I think its a little clearer to just use this stdlib function - what do you think @b1101 ?

I also snuck a .gitignore in here, I can remove if you don't want it.